### PR TITLE
Why do we have our own binary format, rather then using LLVM-IR/bitcode?

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -165,3 +165,6 @@ together in a number of configurations:
   * When WebAssembly [gains the ability to access garbage-collected objects](FutureFeatures.md#gcdom-integration),
     those objects will be shared with JS, and not live in a walled-off world of their own.
 
+## Why do we have our own binary format, rather then using LLVM-IR/bitcode?
+
+LLVM bitcode/IR is not portable and stable enough to be used in a portable manner. LLVM-IR is used for compiler optimization, and hence has a large surface area to cover, more then what is needed for our purposes. Our own binary format allows us to easily create a polyfill for features that require one. It also easily translates to other compiler IR's, rather then being stuck with one/


### PR DESCRIPTION
This branch answers this question using the info gleaned from Issue #188.